### PR TITLE
include instructions for enabling network extensions

### DIFF
--- a/doc/INSTALLING
+++ b/doc/INSTALLING
@@ -18,6 +18,12 @@ cd to your gurbalib dir and perform the following actions:
 	tar xvf dgd-*.tar
 		extract the tar file.
 	cd dgd/src
+	edit Makefile if you want networking
+		to enable support for intermud and the ftp daemon, change
+		the line that looks like:
+		DEFINES=-D$(HOST)        #-DNETWORK_EXTENSIONS -DCLOSURES -DCO_THROTTLE=50 -DDUMP_FUNCS
+		to:
+		DEFINES=-D$(HOST)        -DNETWORK_EXTENSIONS #-DCLOSURES -DCO_THROTTLE=50 -DDUMP_FUNCS
 	make
 	make install
 	cd ../../..


### PR DESCRIPTION
I've inserted instructions for enabling network extensions to make it explicit that you need those extensions if you want support for intermud and the ftp daemon.
