### PR TITLE
Networking extensions are no longer supported by DGD.

### DIFF
--- a/mud.dgd.examp
+++ b/mud.dgd.examp
@@ -3,8 +3,6 @@ directory	= "/gurbalib/lib/";
 
 users		= 40;			/* max # of users */
 editors		= 40;			/* max # of editor sessions */
-ports		= 16;			/* max # of open ports
-						(for network extensions) */
 telnet_port	= 4000;			/* telnet port number */
 binary_port	= 4001;
 


### PR DESCRIPTION
Remove ports option from config file.