### PR TITLE
Remove open_port afun.

### DIFF
--- a/lib/kernel/lib/afun/open_port.c
+++ b/lib/kernel/lib/afun/open_port.c
@@ -1,8 +1,0 @@
-static void open_port(mixed args ...) {
-   if (!require_priv("system")) {
-      error("Illegal call to open_port");
-   }
-#ifdef SYS_NETWORKING
-   ::open_port(args...);
-#endif
-}


### PR DESCRIPTION
open_port was part of DGD's networking extensions and is no longer supported.