### PR TITLE
Update combat.c to fix infinite defense issue

### DIFF
--- a/lib/std/combat.c
+++ b/lib/std/combat.c
@@ -192,10 +192,17 @@ void damage_target(int dam, object who) {
 }
 
 int query_defense(void) {
-   int me, i, max;
+   int me, i, max, skill;
    object *armor;
+   
+   /* this section needed to prevent defence from going infinite */
+   /* random(0) causes the full range to be used */
+   skill = (this_object()->query_skill("combat/defense") / 50);
+   if (skill == 0) {
+      skill = 1;
+   }
 
-   me = random(this_object()->query_skill("combat/defense") / 50);
+   me = random(skill);
    me += this_object()->query_statbonus("dex");
    armor = this_object()->query_equipment();
 


### PR DESCRIPTION
Combat.c needs a fix

this patch forces a minimum defense of 1 to prevent overflow when random(0) is called which uses the full int range.