### PR TITLE
Add PK Safe

### DIFF
--- a/lib/std/combat.c
+++ b/lib/std/combat.c
@@ -194,7 +194,7 @@ void damage_target(int dam, object who) {
 int query_defense(void) {
    int me, i, max, skill;
    object *armor;
-   
+
    /* this section needed to prevent defence from going infinite */
    /* random(0) causes the full range to be used */
    skill = (this_object()->query_skill("combat/defense") / 50);
@@ -351,7 +351,7 @@ void attack_with(string skill, object weapon, object target) {
          tmp = this_object()->query_skill("combat/unarmed") +
             this_object()->query_skill("combat/unarmed") / 2;
          if (tmp <= target->query_skill("combat/defense")) {
-            this_object()->learn_skill(this_object()->query_hit_skill());
+            this_object()->learn_skill("combat/unarmed");
 #ifdef DEBUG_COMBAT
             this_object()->message("Learn: hit_skill, " +
                this_object()->query_skill("combat/unarmed"));
@@ -386,7 +386,7 @@ void attack_with(string skill, object weapon, object target) {
          damage = target->after_damage_hook(this_object(), weapon, damage);
 
          if (damage == 0) {
-            this_object()->targeted_action("$N " + 
+            this_object()->targeted_action("$N " +
                "$v" + weapon->query_weapon_action() + " $T with a " +
                weapon->query_id() + ", but $vdo no damage!", target);
          } else {
@@ -582,7 +582,7 @@ string *summarise_killers(void) {
       done = 1;
    }
 
-   if (!done) { 
+   if (!done) {
       lines += ({ "So far you have been spared, count yourself lucky.\n" });
    } else {
 
@@ -596,4 +596,3 @@ string *summarise_killers(void) {
 
    return lines;
 }
-

--- a/lib/std/room.c
+++ b/lib/std/room.c
@@ -3,7 +3,8 @@
 inherit cont "/std/container";
 
 static mapping exits, hidden_exits, areas, items;
-static int last_exit, weather, light;
+static int last_exit, weather, light, pk;
+
 string dark_msg;
 
 void setup(void);
@@ -75,6 +76,17 @@ void set_weather(int flag) {
 
 int query_weather(void) {
    return weather;
+}
+
+void set_pk(int flag) {
+   pk = flag;
+}
+
+int query_pk(void) {
+  if (!pk) {
+    return 0;
+  }
+  return pk;
 }
 
 void add_area(string str) {


### PR DESCRIPTION
add new functions to room.c and combat.c

```
set_pk(1);
```

This will enable player killing capability for that room, by default
```
query_pk()
```
will return 0, which will stop attack from working if the person is a player