### PR TITLE
Fix levelling twice

### DIFF
--- a/lib/std/body/experience.c
+++ b/lib/std/body/experience.c
@@ -85,7 +85,7 @@ string query_level_title(int level) {
 }
 
 void increase_level(void) {
-   level += 1;
+   level++;
    this_object()->set_max_hp((level *
       this_object()->query_base_stat("str")) + 20);
    this_object()->set_max_mana((level *
@@ -98,7 +98,7 @@ void increase_level(void) {
 
 void increase_expr(int expr) {
    if (expr < 0) {
-      expr = expr * -1;
+      expr = -expr;
    }
    experience += expr;
    if (experience < 0) {
@@ -107,7 +107,6 @@ void increase_expr(int expr) {
    if (ready_for_next_level()) {
       increase_level();
       write("Congratulations, you just went up a level...\n");
-      level += 1;
    }
 }
 

--- a/lib/std/body/experience.c
+++ b/lib/std/body/experience.c
@@ -85,15 +85,16 @@ string query_level_title(int level) {
 }
 
 void increase_level(void) {
+   object to = this_object();
    level++;
-   this_object()->set_max_hp((level *
-      this_object()->query_base_stat("str")) + 20);
-   this_object()->set_max_mana((level *
-      this_object()->query_base_stat("wis")) + 20);
-   this_object()->set_max_end((level *
-      this_object()->query_base_stat("con")) + 20);
+   to->set_max_hp((level *
+      to->query_base_stat("str")) + 20);
+   to->set_max_mana((level *
+      to->query_base_stat("wis")) + 20);
+   to->set_max_end((level *
+      to->query_base_stat("con")) + 20);
    write("Congratulations, you just achieved level: " + level + "\n");
-   this_object()->set_title("$N " + query_level_title(level));
+   to->set_title("$N " + query_level_title(level));
 }
 
 void increase_expr(int expr) {


### PR DESCRIPTION
Fixes `level += 1` being called twice. Reduces the amount of `this_object()` calls in `increase_level()`