### PR TITLE
Update for DGD change, tighter aggregate typechecking.

### DIFF
--- a/lib/std/body/stats.c
+++ b/lib/std/body/stats.c
@@ -197,7 +197,7 @@ void initialize_base_stats(void) {
 
    while (!sOK) {
 
-      s = ({ "0", "0", "0", "0", "0", "0" });
+      s = ({ 0, 0, 0, 0, 0, 0 });
       i = 0;
       for (i = 0; i < 6; i++) {
          s[i] = random(race->query_base_stat_maximum(VALID_STATS[i]) -

--- a/lib/sys/daemons/user_d.c
+++ b/lib/sys/daemons/user_d.c
@@ -593,7 +593,7 @@ object **query_all_online(void) {
 }
 
 string **query_all_online_names(void) {
-   object *a, *m, *w;
+   mixed *a, *m, *w;
 
    ({ a, w, m }) = query_all_online();
 


### PR DESCRIPTION
In commit https://github.com/dworkin/dgd/commit/3ad6ae78f885e3ad357edd430350d33320437001, DGD started constructing types other than `mixed *` for array aggregates. This patch enables Gurbalib to boot again after those changes.